### PR TITLE
fix: add missing upperCaseValidate method call to ensure validation works correctly

### DIFF
--- a/internal/validator.go
+++ b/internal/validator.go
@@ -62,6 +62,7 @@ func (v *Validator) validate() error {
 	v.asciiValidate()
 	v.printableASCIIValidate()
 	v.lowerCaseValidate()
+	v.upperCaseValidate()
 	v.intValidate()
 	v.floatValidate()
 	v.urlValidate()


### PR DESCRIPTION
The upperCaseValidate method was not being called, which caused issues with validating upper-case values. This fix ensures the validation logic is complete and behaves as expected.
